### PR TITLE
Use standard logger for Kafka logs

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -28,15 +28,15 @@ main = do
   let kafkaConf = opt ^. optKafkaConfig
   let statsConf = opt ^. optStatsConfig
 
-  withStdOutTimedFastLogger $ \logger -> do
+  withStdOutTimedFastLogger $ \lgr -> do
     withStatsClient progName statsConf $ \stats -> do
-      envAws <- mkEnv (opt ^. optRegion) logLevel logger
-      let envApp = AppEnv opt stats logger
+      envAws <- mkEnv (opt ^. optRegion) logLevel lgr
+      let envApp = AppEnv opt stats lgr
 
       void . runApplication envAws envApp $ do
         logInfo "Creating Kafka Consumer"
-        consumer <- mkConsumer logLevel kafkaConf
-        -- producer <- mkProducer kafkaConf -- Use this if you also want a producer.
+        consumer <- mkConsumer logLevel lgr kafkaConf
+        -- producer <- mkProducer logLevel lgr kafkaConf -- Use this if you also want a producer.
 
         logInfo "Instantiating Schema Registry"
         sr <- schemaRegistry (kafkaConf ^. schemaRegistryAddress)
@@ -52,7 +52,7 @@ main = do
           .| commitOffsetsSink consumer
           -- .| flushThenCommitSink consumer producer -- Swap with the above if you want a producer.
 
-    pushLogMessage logger LevelError ("Premature exit, must not happen." :: String)
+    pushLogMessage lgr LevelError ("Premature exit, must not happen." :: String)
 
 withStatsClient :: AppName -> StatsConfig -> (StatsClient -> IO ()) -> IO ()
 withStatsClient appName statsConf f = do

--- a/src/App/AppEnv.hs
+++ b/src/App/AppEnv.hs
@@ -16,3 +16,24 @@ data AppEnv = AppEnv
   }
 
 makeClassy ''AppEnv
+
+class HasStatsClient a where
+  statsClient :: Lens' a StatsClient
+
+instance HasStatsClient StatsClient where
+  statsClient = id
+
+instance HasStatsClient AppEnv where
+  statsClient = appStatsClient
+
+class HasLogger a where
+  logger :: Lens' a TimedFastLogger
+
+instance HasLogger AppEnv where
+  logger = appLogger
+
+instance HasKafkaConfig AppEnv where
+  kafkaConfig = appEnv . kafkaConfig
+
+instance HasStatsConfig AppEnv where
+  statsConfig = appEnv . statsConfig

--- a/src/App/Kafka.hs
+++ b/src/App/Kafka.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
 module App.Kafka
 where
 
 import App.Options
+import Arbor.Logger
 import Control.Lens                 hiding (cons)
 import Control.Monad                (void)
 import Control.Monad.Logger         (LogLevel (..))
@@ -13,25 +15,33 @@ import Kafka.Conduit.Sink           as KSnk
 import Kafka.Conduit.Source         as KSrc
 
 
-mkConsumer :: MonadResource m => LogLevel -> KafkaConfig -> m KafkaConsumer
-mkConsumer l conf =
+-- Can be this:
+-- mkConsumer :: (MonadResource m, MonadReader r m, HasKafkaConfig r, HasLogger r) => LogLevel -> m KafkaConsumer
+-- I can't decide which one is better so I leave this comment
+mkConsumer :: MonadResource m => LogLevel -> TimedFastLogger -> KafkaConfig -> m KafkaConsumer
+mkConsumer lvl lgr conf =
   let props = fold
         [ KSrc.brokersList [conf ^. broker]
         , conf ^. consumerGroupId    & groupId
         , conf ^. queuedMaxMsgKBytes & queuedMaxMessagesKBytes
         , noAutoCommit
         , KSrc.suppressDisconnectLogs
-        , consumerLogLevel (kafkaLogLevel l)
+        , consumerLogLevel (kafkaLogLevel lvl)
         , KSrc.debugOptions (kafkaDebugEnable (conf ^. debugOpts))
+        , KSrc.setCallback (logCallback   (\l s1 s2 -> pushLogMessage lgr (kafkaLogLevelToLogLevel $ toEnum l) ("[" <> s1 <> "] " <> s2)))
+        , KSrc.setCallback (errorCallback (\e s -> pushLogMessage lgr LevelError ("[" <> show e <> "] " <> s)))
         ]
       sub = topics [conf ^. inputTopic] <> offsetReset Earliest
       cons = newConsumer props sub >>= either throwM return
    in snd <$> allocate cons (void . closeConsumer)
 
-mkProducer :: MonadResource m => KafkaConfig -> m KafkaProducer
-mkProducer conf =
+mkProducer :: MonadResource m => LogLevel -> TimedFastLogger -> KafkaConfig -> m KafkaProducer
+mkProducer lvl lgr conf =
   let props = KSnk.brokersList [conf ^. broker]
            <> KSnk.suppressDisconnectLogs
+           <> logLevel (kafkaLogLevel lvl)
+           <> KSnk.setCallback (logCallback   (\l s1 s2 -> pushLogMessage lgr (kafkaLogLevelToLogLevel $ toEnum l) ("[" <> s1 <> "] " <> s2)))
+           <> KSnk.setCallback (errorCallback (\e s -> pushLogMessage lgr LevelError ("[" <> show e <> "] " <> s)))
       prod = newProducer props >>= either throwM return
    in snd <$> allocate prod closeProducer
 
@@ -42,6 +52,17 @@ kafkaLogLevel l = case l of
   LevelWarn    -> KafkaLogWarning
   LevelError   -> KafkaLogErr
   LevelOther _ -> KafkaLogCrit
+
+kafkaLogLevelToLogLevel :: KafkaLogLevel -> LogLevel
+kafkaLogLevelToLogLevel l = case l of
+  KafkaLogDebug   -> LevelDebug
+  KafkaLogInfo    -> LevelInfo
+  KafkaLogWarning -> LevelWarn
+  KafkaLogErr     -> LevelError
+  KafkaLogCrit    -> LevelError
+  KafkaLogAlert   -> LevelWarn
+  KafkaLogNotice  -> LevelInfo
+  KafkaLogEmerg   -> LevelError
 
 kafkaDebugEnable :: String -> [KafkaDebug]
 kafkaDebugEnable str = map debug (splitWhen (== ',') str)

--- a/src/App/Options.hs
+++ b/src/App/Options.hs
@@ -49,6 +49,12 @@ makeClassy ''KafkaConfig
 makeClassy ''StatsConfig
 makeClassy ''Options
 
+instance HasKafkaConfig Options where
+  kafkaConfig = optKafkaConfig
+
+instance HasStatsConfig Options where
+  statsConfig = optStatsConfig
+
 statsConfigParser :: Parser StatsConfig
 statsConfigParser = StatsConfig
   <$> strOption


### PR DESCRIPTION
## Changes

Have this output:
```
[Info] [2017-09-29 16:09:36] Creating Kafka Consumer
[Debug] [2017-09-29 16:09:36] [BROKER] [thrd:app]: localhost:9092/bootstrap: Added new broker with NodeId -1
[Debug] [2017-09-29 16:09:36] [BRKMAIN] [thrd::0/internal]: :0/internal: Enter main broker thread
[Info] [2017-09-29 16:09:36] Instantiating Schema Registry
[Info] [2017-09-29 16:09:36] Running Kafka Consumer
[Error] [2017-09-29 16:09:36] [KafkaResponseError RdKafkaRespErrTransport] localhost:9092/bootstrap: Connect to ipv6#[::1]:9092 failed: Connection refused
[Error] [2017-09-29 16:09:36] [KafkaResponseError RdKafkaRespErrAllBrokersDown] 1/1 brokers are down
```

Instead of this:
```
[Info] [2017-09-29 16:10:41] Creating Kafka Consumer
%7|1506665441.841|BRKMAIN|rdkafka#consumer-1| [thrd::0/internal]: :0/internal: Enter main broker thread
%7|1506665441.841|STATE|rdkafka#consumer-1| [thrd::0/internal]: :0/internal: Broker changed state INIT -> UP
%7|1506665441.841|BROKER|rdkafka#consumer-1| [thrd:app]: localhost:9092/bootstrap: Added new broker with NodeId -1
%3|1506665441.842|FAIL|rdkafka#consumer-1| [thrd:localhost:9092/bootstrap]: localhost:9092/bootstrap: Connect to ipv6#[::1]:9092 failed: Connection refused
%3|1506665441.842|ERROR|rdkafka#consumer-1| [thrd:localhost:9092/bootstrap]: localhost:9092/bootstrap: Connect to ipv6#[::1]:9092 failed: Connection refused
%3|1506665441.842|ERROR|rdkafka#consumer-1| [thrd:localhost:9092/bootstrap]: 1/1 brokers are down
```

Plus a bit more lensification